### PR TITLE
Empty nodes still creates icon

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -528,13 +528,15 @@
 			// Add expand, collapse or empty spacer icons
 			var classList = [];
 			if (node.nodes) {
-				classList.push('expand-icon');
-				if (node.state.expanded) {
-					classList.push(_this.options.collapseIcon);
-				}
-				else {
-					classList.push(_this.options.expandIcon);
-				}
+			    if (node.nodes.length > 0) {
+			        classList.push('expand-icon');
+			        if (node.state.expanded) {
+			            classList.push(_this.options.collapseIcon);
+			        }
+			        else {
+			            classList.push(_this.options.expandIcon);
+			        }
+			    }
 			}
 			else {
 				classList.push(_this.options.emptyIcon);


### PR DESCRIPTION
Empty nodes array property still creates collapse/expanse icon. 